### PR TITLE
Peripheral function selection can't be in drivers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -90,21 +90,26 @@ fn init_console() -> drivers::uart::console::Console<usart::USART> {
         location: usart::Location::USART3
     });
 
-    let pin_9 = gpio::GPIOPin::new(gpio::Params {
+    let mut pin_9 = gpio::GPIOPin::new(gpio::Params {
         location: gpio::Location::GPIOPin9,
         port: gpio::GPIOPort::GPIO1
     });
 
-    let pin_10 = gpio::GPIOPin::new(gpio::Params {
+    let mut pin_10 = gpio::GPIOPin::new(gpio::Params {
         location: gpio::Location::GPIOPin10,
         port: gpio::GPIOPort::GPIO1
     });
+
+    // Set pins to peripheral function USART3
+    pin_9.select_peripheral(gpio::PeripheralFunction::A);
+    pin_10.select_peripheral(gpio::PeripheralFunction::A);
+
 
     // USART3 clock; this should probably be in USART's init, and should likely
     // depend on the location.
     pm::enable_pba_clock(11);
 
-    drivers::uart::console::init(uart_3, pin_9, pin_10,
+    drivers::uart::console::init(uart_3,
         drivers::uart::console::InitParams {
             baud_rate: 115200,
             data_bits: 8,
@@ -112,3 +117,4 @@ fn init_console() -> drivers::uart::console::Console<usart::USART> {
         }
     )
 }
+

--- a/src/drivers/uart/console.rs
+++ b/src/drivers/uart/console.rs
@@ -1,4 +1,4 @@
-use hil::{GPIOPin, UART, UARTParams, Parity, PeripheralFunction};
+use hil::{UART, UARTParams, Parity};
 use core::prelude::*;
 
 #[derive(Copy)]
@@ -29,12 +29,8 @@ impl<T: UART> Console<T> {
     }
 }
 
-pub fn init<U,P>(mut uart: U, mut pin1: P, mut pin2: P, params: InitParams)
-        -> Console<U> where U: UART, P: GPIOPin {
-    // Setup pins to function as USB device
-    pin1.select_peripheral(PeripheralFunction::A);
-    pin2.select_peripheral(PeripheralFunction::A);
-
+pub fn init<U>(mut uart: U, params: InitParams)
+        -> Console<U> where U: UART {
     uart.init(UARTParams {
         baud_rate: params.baud_rate,
         data_bits: params.data_bits,

--- a/src/hil/gpio.rs
+++ b/src/hil/gpio.rs
@@ -1,13 +1,7 @@
-#[derive(Copy)]
-pub enum PeripheralFunction {
-    A, B, C, D, E, F, G, H
-}
-
 pub trait GPIOPin {
     fn enable_output(&mut self);
     fn set(&mut self);
     fn clear(&mut self);
     fn toggle(&mut self);
     fn read(&self) -> bool;
-    fn select_peripheral(&mut self, PeripheralFunction);
 }


### PR DESCRIPTION
Peripheral function is platform specific (sam4l) _and_ pin specific. You
have to have global knowledge of the platform wiring to know which pins
to use and how to select them. For exmple, the console can't just select
function A, because sometimes A means USART, while for other pins
another function is USART. Same issue with putting them in platform drivers.

So logical place is to select pin functions as the platform driver is
being instantiated but outside of both the plaform and device driver.
