### PR TITLE
Make ADC compile

### DIFF
--- a/src/hil/lib.rs
+++ b/src/hil/lib.rs
@@ -17,4 +17,4 @@ pub mod i2c;
 pub mod spi;
 pub mod timer;
 pub mod uart;
-// pub mod adc;
+pub mod adc;

--- a/src/platform/sam4l/adc.rs
+++ b/src/platform/sam4l/adc.rs
@@ -1,4 +1,4 @@
-/*
+
 use core::intrinsics;
 use hil::adc;
 use sam4l::pm::{self, Clock, PBAClock};
@@ -37,7 +37,7 @@ pub const BASE_ADDRESS: usize = 0x40038000;
 
 // -1 means no channel active
 static mut WHICH_ACTIVE : isize = -1;
-static mut BUSY: bool = false;
+static mut BUSY: isize = 0;
 
 #[allow(missing_copy_implementations)]
 pub struct ADC {
@@ -85,10 +85,10 @@ impl adc::ADCMaster for ADC {
             return true;
         } else {
             let busy = unsafe {
-                let state  = &mut BUSY as *mut bool;
-                intrinsics::atomic_xchg(state, true)
+                let state  = &mut BUSY as *mut isize;
+                intrinsics::atomic_xchg(state, 1)
             };
-            if busy == false {
+            if busy == 0 {
                 self.enabled = true;
                 unsafe {
                     let which_active = &mut WHICH_ACTIVE as *mut isize;
@@ -110,14 +110,14 @@ impl adc::ADCMaster for ADC {
         unsafe {
             let which_active = &mut WHICH_ACTIVE as *mut isize;
             intrinsics::atomic_store(which_active, -1);
-            let state  = &mut BUSY as *mut bool;
-            intrinsics::atomic_store(state, false)
+            let state  = &mut BUSY as *mut isize;
+            intrinsics::atomic_store(state, 0)
         };
         self.enabled = false;
     }
 
     fn is_enabled(&self) -> bool {
-       self.enabled
+        self.enabled
     }
 
     fn sample(&mut self) -> u16 {
@@ -128,4 +128,4 @@ impl adc::ADCMaster for ADC {
         }
     }
 }
-*/
+

--- a/src/platform/sam4l/mod.rs
+++ b/src/platform/sam4l/mod.rs
@@ -5,4 +5,4 @@ pub mod nvic;
 pub mod pm;
 pub mod spi;
 pub mod usart;
-// pub mod adc;
+pub mod adc;


### PR DESCRIPTION
@phil-levis this is for you:

The problem was that (for some reason) LLVM doesn't see the BUSY bool as
a `Value` (a class in LLVM that all values derive from), which is
necessary to use the StoreInst compiler intrinsic (generated from
`atomic_store`). The workaround is to make BUSY an isize for now, where
0 == false and 1 == true.
